### PR TITLE
Add Jest unit test for utils

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/tests/**/*.test.ts'],
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",
@@ -65,6 +66,9 @@
     "@types/node": "^22",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/jest": "^29.5.8",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.2",
     "postcss": "^8",
     "tailwindcss": "^3.4.17",
     "typescript": "^5"

--- a/tests/lib.utils.test.ts
+++ b/tests/lib.utils.test.ts
@@ -1,0 +1,7 @@
+import { cn } from '../lib/utils'
+
+describe('cn utility', () => {
+  it('returns a concatenated string excluding undefined values', () => {
+    expect(cn('a', undefined, 'b')).toBe('a b')
+  })
+})


### PR DESCRIPTION
## Summary
- set up Jest with ts-jest
- add `test` script in `package.json`
- include unit test for `cn` utility

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855c3fdec24832093dc130476c47e03